### PR TITLE
Fix failing compiles on Linux

### DIFF
--- a/include/ir.h
+++ b/include/ir.h
@@ -3,6 +3,8 @@
 #include "util.h"
 #include <deque>
 #include <list>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/optimize.cpp
+++ b/src/optimize.cpp
@@ -1,5 +1,6 @@
 #include "../include/optimize.h"
 #include "../include/lib/library.h"
+#include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4,6 +4,7 @@
 #include "../include/optimize.h"
 #include "../include/scanner.h"
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <list>


### PR DESCRIPTION
Current master fails to build on Linux, this PR includes the necessary headers for the build to succeed. Keep in mind that this was not tested on MacOS and further modifications may be necessary.